### PR TITLE
Fixed RStudio Viewer bug on d3tree3 on Windows machine

### DIFF
--- a/inst/htmlwidgets/d3tree3.js
+++ b/inst/htmlwidgets/d3tree3.js
@@ -41,21 +41,25 @@ HTMLWidgets.widget({
 
     // experiment to add a legend if provided from treemap
     if (x.legend){
-      var legend = svg.append("g")
-                      .attr("class","legend");
-      legend[0][0].innerHTML = x.legend.join(" ");
+      var regExp = /<rect id="GRID\.rect.*fill="(rgb\(.{5,15}\))"/g;
+      var arrayOfRects = [];
+
+      var m;
+      do {
+          m = regExp.exec(x.legend);
+          if (m) {
+            arrayOfRects.push(m[1]);
+          }
+      } while (m);
 
       //Pulls colors out of DOM and constructs legend fade object
       var colors = [];
-      var arrayOfRects = d3.select('g#legenda\\.1').selectAll("g").selectAll('rect')[0];
       arrayOfRects.forEach(function(d, i) {
         colors.push({
            "offset" : (100 / (arrayOfRects.length - 1)) * i + "%",
-           "color" : d.getAttribute("fill")
+           "color" : d
         });
       });
-      //removes legend that we don't need anymore
-      legend.remove();
 
       //construct legend data object
 

--- a/inst/htmlwidgets/lib/d3tree2/d3tree2.css
+++ b/inst/htmlwidgets/lib/d3tree2/d3tree2.css
@@ -33,16 +33,10 @@
 }
 
 .d3tree2 .children rect.child {
-  opacity: 1;
-  stroke-width:0;
+  opacity: 0;
 }
 
 .d3tree2 .children rect.parent {
-  fill-opacity:0;
-  stroke-width: 2px;
-}
-.d3tree2 .children:hover rect.parent {
-  stroke-width: 9px;
 }
 
 .d3tree2 .children text{
@@ -50,9 +44,10 @@
 }
 
 .d3tree2 .children:hover rect.child {
-
+  opacity: 1;
+  stroke-width: 1px;
 }
 
 .d3tree2 .children:hover rect.parent {
-
+  opacity: 0;
 }


### PR DESCRIPTION
`d3tree3` should work in the RStudio Viewer on a Windows machine now.  Used regex to parse out colors from x.legend string instead of attaching the legend to the DOM and pulling out the attributes.
